### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pmemkv-python (1.0-5) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 22 Oct 2022 00:30:46 -0000
+
 pmemkv-python (1.0-4) unstable; urgency=medium
 
   * Enable riscv64.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ pmemkv-python (1.0-5) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 22 Oct 2022 00:30:46 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (= 13),
                python3-all,
                python3-setuptools,
                python3-sphinx,
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/pmem/pmemkv-python
 Vcs-Browser: https://github.com/kilobyte/pmemkv-python/tree/debian

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/pmem/pmemkv-python/issues
+Bug-Submit: https://github.com/pmem/pmemkv-python/issues/new
+Repository: https://github.com/pmem/pmemkv-python.git
+Repository-Browse: https://github.com/pmem/pmemkv-python


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/pmemkv-python/caf18b18-6845-444a-967c-129864520b01.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/caf18b18-6845-444a-967c-129864520b01/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/caf18b18-6845-444a-967c-129864520b01/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/caf18b18-6845-444a-967c-129864520b01/diffoscope)).
